### PR TITLE
Add grid cvmfs software repository

### DIFF
--- a/CERN-PROD_CLOUD.yaml
+++ b/CERN-PROD_CLOUD.yaml
@@ -834,7 +834,7 @@ write_files:
 
 cvmfs:
  local:
-  CVMFS_REPOSITORIES: atlas.cern.ch,atlas-condb.cern.ch,atlas-nightlies.cern.ch,sft.cern.ch
+  CVMFS_REPOSITORIES: atlas.cern.ch,atlas-condb.cern.ch,atlas-nightlies.cern.ch,grid.cern.ch,sft.cern.ch
   CVMFS_HTTP_PROXY: kraken01.westgrid.ca:3128
  domain:
   CVMFS_SERVER_URL: '"http://cvmfs-stratum-one.cern.ch:8000/opt/@org@;http://cernvmfs.gridpp.rl.ac.uk:8000/opt/@org@;http://cvmfs.racf.bnl.gov:8000/opt/@org@;http://cvmfs.fnal.gov:8000/opt/@org@;http://cvmfs02.grid.sinica.edu.tw:8000/opt/@org@"'

--- a/CERN-PROD_CLOUD_MCORE.yaml
+++ b/CERN-PROD_CLOUD_MCORE.yaml
@@ -834,7 +834,7 @@ write_files:
 
 cvmfs:
  local:
-  CVMFS_REPOSITORIES: atlas.cern.ch,atlas-condb.cern.ch,atlas-nightlies.cern.ch,sft.cern.ch
+  CVMFS_REPOSITORIES: atlas.cern.ch,atlas-condb.cern.ch,atlas-nightlies.cern.ch,grid.cern.ch,sft.cern.ch
   CVMFS_HTTP_PROXY: kraken01.westgrid.ca:3128
  domain:
   CVMFS_SERVER_URL: '"http://cvmfs-stratum-one.cern.ch:8000/opt/@org@;http://cernvmfs.gridpp.rl.ac.uk:8000/opt/@org@;http://cvmfs.racf.bnl.gov:8000/opt/@org@;http://cvmfs.fnal.gov:8000/opt/@org@;http://cvmfs02.grid.sinica.edu.tw:8000/opt/@org@"'

--- a/GOOGLE_COMPUTE_ENGINE.yaml
+++ b/GOOGLE_COMPUTE_ENGINE.yaml
@@ -777,7 +777,7 @@ write_files:
 
 cvmfs:
  local:
-  CVMFS_REPOSITORIES: atlas.cern.ch,atlas-condb.cern.ch,atlas-nightlies.cern.ch,sft.cern.ch
+  CVMFS_REPOSITORIES: atlas.cern.ch,atlas-condb.cern.ch,atlas-nightlies.cern.ch,grid.cern.ch,sft.cern.ch
   CVMFS_HTTP_PROXY: kraken01.westgrid.ca:3128
  domain:
   CVMFS_SERVER_URL: '"http://cvmfs.racf.bnl.gov:8000/opt/@org@;http://cvmfs.fnal.gov:8000/opt/@org@;http://cernvmfs.gridpp.rl.ac.uk:8000/opt/@org@;http://cvmfs-stratum-one.cern.ch:8000/opt/@org@;http://cvmfs02.grid.sinica.edu.tw:8000/opt/@org@"'

--- a/GRIDPP_CLOUD.yaml
+++ b/GRIDPP_CLOUD.yaml
@@ -834,7 +834,7 @@ write_files:
 
 cvmfs:
  local:
-  CVMFS_REPOSITORIES: atlas.cern.ch,atlas-condb.cern.ch,atlas-nightlies.cern.ch,sft.cern.ch
+  CVMFS_REPOSITORIES: atlas.cern.ch,atlas-condb.cern.ch,atlas-nightlies.cern.ch,grid.cern.ch,sft.cern.ch
   CVMFS_HTTP_PROXY: kraken01.westgrid.ca:3128
  domain:
   CVMFS_SERVER_URL: '"http://cernvmfs.gridpp.rl.ac.uk:8000/opt/@org@;http://cvmfs-stratum-one.cern.ch:8000/opt/@org@;http://cvmfs.racf.bnl.gov:8000/opt/@org@;http://cvmfs.fnal.gov:8000/opt/@org@;http://cvmfs02.grid.sinica.edu.tw:8000/opt/@org@"'

--- a/GRIDPP_MCORE.yaml
+++ b/GRIDPP_MCORE.yaml
@@ -834,7 +834,7 @@ write_files:
 
 cvmfs:
  local:
-  CVMFS_REPOSITORIES: atlas.cern.ch,atlas-condb.cern.ch,atlas-nightlies.cern.ch,sft.cern.ch
+  CVMFS_REPOSITORIES: atlas.cern.ch,atlas-condb.cern.ch,atlas-nightlies.cern.ch,grid.cern.ch,sft.cern.ch
   CVMFS_HTTP_PROXY: kraken01.westgrid.ca:3128
  domain:
   CVMFS_SERVER_URL: '"http://cernvmfs.gridpp.rl.ac.uk:8000/opt/@org@;http://cvmfs-stratum-one.cern.ch:8000/opt/@org@;http://cvmfs.racf.bnl.gov:8000/opt/@org@;http://cvmfs.fnal.gov:8000/opt/@org@;http://cvmfs02.grid.sinica.edu.tw:8000/opt/@org@"'

--- a/IAAS.yaml
+++ b/IAAS.yaml
@@ -834,7 +834,7 @@ write_files:
 
 cvmfs:
  local:
-  CVMFS_REPOSITORIES: atlas.cern.ch,atlas-condb.cern.ch,atlas-nightlies.cern.ch,sft.cern.ch
+  CVMFS_REPOSITORIES: atlas.cern.ch,atlas-condb.cern.ch,atlas-nightlies.cern.ch,grid.cern.ch,sft.cern.ch
   CVMFS_HTTP_PROXY: kraken01.westgrid.ca:3128
  domain:
   CVMFS_SERVER_URL: '"http://cvmfs.racf.bnl.gov:8000/opt/@org@;http://cvmfs.fnal.gov:8000/opt/@org@;http://cernvmfs.gridpp.rl.ac.uk:8000/opt/@org@;http://cvmfs-stratum-one.cern.ch:8000/opt/@org@;http://cvmfs02.grid.sinica.edu.tw:8000/opt/@org@"'

--- a/IAAS_MCORE.yaml
+++ b/IAAS_MCORE.yaml
@@ -834,7 +834,7 @@ write_files:
 
 cvmfs:
  local:
-  CVMFS_REPOSITORIES: atlas.cern.ch,atlas-condb.cern.ch,atlas-nightlies.cern.ch,sft.cern.ch
+  CVMFS_REPOSITORIES: atlas.cern.ch,atlas-condb.cern.ch,atlas-nightlies.cern.ch,grid.cern.ch,sft.cern.ch
   CVMFS_HTTP_PROXY: kraken01.westgrid.ca:3128
  domain:
   CVMFS_SERVER_URL: '"http://cvmfs.racf.bnl.gov:8000/opt/@org@;http://cvmfs.fnal.gov:8000/opt/@org@;http://cernvmfs.gridpp.rl.ac.uk:8000/opt/@org@;http://cvmfs-stratum-one.cern.ch:8000/opt/@org@;http://cvmfs02.grid.sinica.edu.tw:8000/opt/@org@"'

--- a/UKI-NORTHGRID-LANCS-HEP_CLOUD.yaml
+++ b/UKI-NORTHGRID-LANCS-HEP_CLOUD.yaml
@@ -834,7 +834,7 @@ write_files:
 
 cvmfs:
  local:
-  CVMFS_REPOSITORIES: atlas.cern.ch,atlas-condb.cern.ch,atlas-nightlies.cern.ch,sft.cern.ch
+  CVMFS_REPOSITORIES: atlas.cern.ch,atlas-condb.cern.ch,atlas-nightlies.cern.ch,grid.cern.ch,sft.cern.ch
   CVMFS_HTTP_PROXY: kraken01.westgrid.ca:3128
  domain:
   CVMFS_SERVER_URL: '"http://cernvmfs.gridpp.rl.ac.uk:8000/opt/@org@;http://cvmfs-stratum-one.cern.ch:8000/opt/@org@;http://cvmfs.racf.bnl.gov:8000/opt/@org@;http://cvmfs.fnal.gov:8000/opt/@org@;http://cvmfs02.grid.sinica.edu.tw:8000/opt/@org@"'


### PR DESCRIPTION
Hi All,

Quick contribution to adress issue #6 

Add the grid.cern.ch repository explicitly. Condor GSI authentication
relies on the CA certificates provided there. This dependency is hidden
since the /etc/grid-security/certificates links into the grid
repository.

Changes:
	modified:   CERN-PROD_CLOUD.yaml
	modified:   CERN-PROD_CLOUD_MCORE.yaml
	modified:   GOOGLE_COMPUTE_ENGINE.yaml
	modified:   GRIDPP_CLOUD.yaml
	modified:   GRIDPP_MCORE.yaml
	modified:   IAAS.yaml
	modified:   IAAS_MCORE.yaml
	modified:   UKI-NORTHGRID-LANCS-HEP_CLOUD.yaml

The belle yaml blob already contained the grid.cern.ch repository so no need to update there.

Best Regards,
-Frank