### PR TITLE
Define home in profile.d

### DIFF
--- a/CERN-PROD_CLOUD.yaml
+++ b/CERN-PROD_CLOUD.yaml
@@ -25,7 +25,6 @@ write_files:
         # Workaround for condor not setting $HOME for worker sessions.
         # voms-proxy-info requires this.
         export HOME=`eval echo ~$USER`
-        exec "$@"
 
         # Define atlas software location
         export VO_ATLAS_SW_DIR=/cvmfs/atlas.cern.ch/repo/sw
@@ -51,6 +50,7 @@ write_files:
         # Condor startd jobwrapper
         # Executes using bash -l, so that all /etc/profile.d/*.sh scripts are sourced.
         #
+        exec "$@"
     owner: root:root
     permissions: '0755'
     path: /usr/libexec/condor/jobwrapper.sh

--- a/CERN-PROD_CLOUD.yaml
+++ b/CERN-PROD_CLOUD.yaml
@@ -22,6 +22,11 @@ write_files:
             return 0
         fi
 
+        # Workaround for condor not setting $HOME for worker sessions.
+        # voms-proxy-info requires this.
+        export HOME=`eval echo ~$USER`
+        exec "$@"
+
         # Define atlas software location
         export VO_ATLAS_SW_DIR=/cvmfs/atlas.cern.ch/repo/sw
 
@@ -46,11 +51,6 @@ write_files:
         # Condor startd jobwrapper
         # Executes using bash -l, so that all /etc/profile.d/*.sh scripts are sourced.
         #
-
-        # Workaround for condor not setting $HOME for worker sessions.
-        # voms-proxy-info requires this.
-        export HOME=`eval echo ~$USER`
-        exec "$@"
     owner: root:root
     permissions: '0755'
     path: /usr/libexec/condor/jobwrapper.sh

--- a/CERN-PROD_CLOUD_MCORE.yaml
+++ b/CERN-PROD_CLOUD_MCORE.yaml
@@ -25,7 +25,6 @@ write_files:
         # Workaround for condor not setting $HOME for worker sessions.
         # voms-proxy-info requires this.
         export HOME=`eval echo ~$USER`
-        exec "$@"
 
         # Define atlas software location
         export VO_ATLAS_SW_DIR=/cvmfs/atlas.cern.ch/repo/sw
@@ -51,6 +50,7 @@ write_files:
         # Condor startd jobwrapper
         # Executes using bash -l, so that all /etc/profile.d/*.sh scripts are sourced.
         #
+        exec "$@"
     owner: root:root
     permissions: '0755'
     path: /usr/libexec/condor/jobwrapper.sh

--- a/CERN-PROD_CLOUD_MCORE.yaml
+++ b/CERN-PROD_CLOUD_MCORE.yaml
@@ -22,6 +22,11 @@ write_files:
             return 0
         fi
 
+        # Workaround for condor not setting $HOME for worker sessions.
+        # voms-proxy-info requires this.
+        export HOME=`eval echo ~$USER`
+        exec "$@"
+
         # Define atlas software location
         export VO_ATLAS_SW_DIR=/cvmfs/atlas.cern.ch/repo/sw
 
@@ -46,11 +51,6 @@ write_files:
         # Condor startd jobwrapper
         # Executes using bash -l, so that all /etc/profile.d/*.sh scripts are sourced.
         #
-
-        # Workaround for condor not setting $HOME for worker sessions.
-        # voms-proxy-info requires this.
-        export HOME=`eval echo ~$USER`
-        exec "$@"
     owner: root:root
     permissions: '0755'
     path: /usr/libexec/condor/jobwrapper.sh

--- a/GOOGLE_COMPUTE_ENGINE.yaml
+++ b/GOOGLE_COMPUTE_ENGINE.yaml
@@ -25,7 +25,6 @@ write_files:
         # Workaround for condor not setting $HOME for worker sessions.
         # voms-proxy-info requires this.
         export HOME=`eval echo ~$USER`
-        exec "$@"
 
         # Define atlas software location
         export VO_ATLAS_SW_DIR=/cvmfs/atlas.cern.ch/repo/sw
@@ -49,6 +48,7 @@ write_files:
         # Condor startd jobwrapper
         # Executes using bash -l, so that all /etc/profile.d/*.sh scripts are sourced.
         #
+        exec "$@"
     owner: root:root
     permissions: '0755'
     path: /usr/libexec/condor/jobwrapper.sh

--- a/GOOGLE_COMPUTE_ENGINE.yaml
+++ b/GOOGLE_COMPUTE_ENGINE.yaml
@@ -22,6 +22,11 @@ write_files:
             return 0
         fi
 
+        # Workaround for condor not setting $HOME for worker sessions.
+        # voms-proxy-info requires this.
+        export HOME=`eval echo ~$USER`
+        exec "$@"
+
         # Define atlas software location
         export VO_ATLAS_SW_DIR=/cvmfs/atlas.cern.ch/repo/sw
 
@@ -44,11 +49,6 @@ write_files:
         # Condor startd jobwrapper
         # Executes using bash -l, so that all /etc/profile.d/*.sh scripts are sourced.
         #
-
-        # Workaround for condor not setting $HOME for worker sessions.
-        # voms-proxy-info requires this.
-        export HOME=`eval echo ~$USER`
-        exec "$@"
     owner: root:root
     permissions: '0755'
     path: /usr/libexec/condor/jobwrapper.sh

--- a/GRIDPP_CLOUD.yaml
+++ b/GRIDPP_CLOUD.yaml
@@ -25,7 +25,6 @@ write_files:
         # Workaround for condor not setting $HOME for worker sessions.
         # voms-proxy-info requires this.
         export HOME=`eval echo ~$USER`
-        exec "$@"
 
         # Define atlas software location
         export VO_ATLAS_SW_DIR=/cvmfs/atlas.cern.ch/repo/sw
@@ -49,6 +48,7 @@ write_files:
         # Condor startd jobwrapper
         # Executes using bash -l, so that all /etc/profile.d/*.sh scripts are sourced.
         #
+        exec "$@"
     owner: root:root
     permissions: '0755'
     path: /usr/libexec/condor/jobwrapper.sh

--- a/GRIDPP_CLOUD.yaml
+++ b/GRIDPP_CLOUD.yaml
@@ -22,6 +22,11 @@ write_files:
             return 0
         fi
 
+        # Workaround for condor not setting $HOME for worker sessions.
+        # voms-proxy-info requires this.
+        export HOME=`eval echo ~$USER`
+        exec "$@"
+
         # Define atlas software location
         export VO_ATLAS_SW_DIR=/cvmfs/atlas.cern.ch/repo/sw
 
@@ -44,11 +49,6 @@ write_files:
         # Condor startd jobwrapper
         # Executes using bash -l, so that all /etc/profile.d/*.sh scripts are sourced.
         #
-
-        # Workaround for condor not setting $HOME for worker sessions.
-        # voms-proxy-info requires this.
-        export HOME=`eval echo ~$USER`
-        exec "$@"
     owner: root:root
     permissions: '0755'
     path: /usr/libexec/condor/jobwrapper.sh

--- a/GRIDPP_MCORE.yaml
+++ b/GRIDPP_MCORE.yaml
@@ -22,6 +22,10 @@ write_files:
             return 0
         fi
 
+        # Workaround for condor not setting $HOME for worker sessions.
+        # voms-proxy-info requires this.
+        export HOME=`eval echo ~$USER`
+
         # Define atlas software location
         export VO_ATLAS_SW_DIR=/cvmfs/atlas.cern.ch/repo/sw
 
@@ -44,10 +48,6 @@ write_files:
         # Condor startd jobwrapper
         # Executes using bash -l, so that all /etc/profile.d/*.sh scripts are sourced.
         #
-
-        # Workaround for condor not setting $HOME for worker sessions.
-        # voms-proxy-info requires this.
-        export HOME=`eval echo ~$USER`
         exec "$@"
     owner: root:root
     permissions: '0755'

--- a/IAAS.yaml
+++ b/IAAS.yaml
@@ -25,7 +25,6 @@ write_files:
         # Workaround for condor not setting $HOME for worker sessions.
         # voms-proxy-info requires this.
         export HOME=`eval echo ~$USER`
-        exec "$@"
 
         # Define atlas software location
         export VO_ATLAS_SW_DIR=/cvmfs/atlas.cern.ch/repo/sw
@@ -49,6 +48,7 @@ write_files:
         # Condor startd jobwrapper
         # Executes using bash -l, so that all /etc/profile.d/*.sh scripts are sourced.
         #
+        exec "$@"
     owner: root:root
     permissions: '0755'
     path: /usr/libexec/condor/jobwrapper.sh

--- a/IAAS.yaml
+++ b/IAAS.yaml
@@ -22,6 +22,11 @@ write_files:
             return 0
         fi
 
+        # Workaround for condor not setting $HOME for worker sessions.
+        # voms-proxy-info requires this.
+        export HOME=`eval echo ~$USER`
+        exec "$@"
+
         # Define atlas software location
         export VO_ATLAS_SW_DIR=/cvmfs/atlas.cern.ch/repo/sw
 
@@ -44,11 +49,6 @@ write_files:
         # Condor startd jobwrapper
         # Executes using bash -l, so that all /etc/profile.d/*.sh scripts are sourced.
         #
-
-        # Workaround for condor not setting $HOME for worker sessions.
-        # voms-proxy-info requires this.
-        export HOME=`eval echo ~$USER`
-        exec "$@"
     owner: root:root
     permissions: '0755'
     path: /usr/libexec/condor/jobwrapper.sh

--- a/IAAS_MCORE.yaml
+++ b/IAAS_MCORE.yaml
@@ -25,7 +25,6 @@ write_files:
         # Workaround for condor not setting $HOME for worker sessions.
         # voms-proxy-info requires this.
         export HOME=`eval echo ~$USER`
-        exec "$@"
 
         # Define atlas software location
         export VO_ATLAS_SW_DIR=/cvmfs/atlas.cern.ch/repo/sw
@@ -49,6 +48,7 @@ write_files:
         # Condor startd jobwrapper
         # Executes using bash -l, so that all /etc/profile.d/*.sh scripts are sourced.
         #
+        exec "$@"
     owner: root:root
     permissions: '0755'
     path: /usr/libexec/condor/jobwrapper.sh

--- a/IAAS_MCORE.yaml
+++ b/IAAS_MCORE.yaml
@@ -22,6 +22,11 @@ write_files:
             return 0
         fi
 
+        # Workaround for condor not setting $HOME for worker sessions.
+        # voms-proxy-info requires this.
+        export HOME=`eval echo ~$USER`
+        exec "$@"
+
         # Define atlas software location
         export VO_ATLAS_SW_DIR=/cvmfs/atlas.cern.ch/repo/sw
 
@@ -44,11 +49,6 @@ write_files:
         # Condor startd jobwrapper
         # Executes using bash -l, so that all /etc/profile.d/*.sh scripts are sourced.
         #
-
-        # Workaround for condor not setting $HOME for worker sessions.
-        # voms-proxy-info requires this.
-        export HOME=`eval echo ~$USER`
-        exec "$@"
     owner: root:root
     permissions: '0755'
     path: /usr/libexec/condor/jobwrapper.sh

--- a/UKI-NORTHGRID-LANCS-HEP_CLOUD.yaml
+++ b/UKI-NORTHGRID-LANCS-HEP_CLOUD.yaml
@@ -25,7 +25,6 @@ write_files:
         # Workaround for condor not setting $HOME for worker sessions.
         # voms-proxy-info requires this.
         export HOME=`eval echo ~$USER`
-        exec "$@"
 
         # Define atlas software location
         export VO_ATLAS_SW_DIR=/cvmfs/atlas.cern.ch/repo/sw
@@ -49,6 +48,7 @@ write_files:
         # Condor startd jobwrapper
         # Executes using bash -l, so that all /etc/profile.d/*.sh scripts are sourced.
         #
+        exec "$@"
     owner: root:root
     permissions: '0755'
     path: /usr/libexec/condor/jobwrapper.sh

--- a/UKI-NORTHGRID-LANCS-HEP_CLOUD.yaml
+++ b/UKI-NORTHGRID-LANCS-HEP_CLOUD.yaml
@@ -22,6 +22,11 @@ write_files:
             return 0
         fi
 
+        # Workaround for condor not setting $HOME for worker sessions.
+        # voms-proxy-info requires this.
+        export HOME=`eval echo ~$USER`
+        exec "$@"
+
         # Define atlas software location
         export VO_ATLAS_SW_DIR=/cvmfs/atlas.cern.ch/repo/sw
 
@@ -44,11 +49,6 @@ write_files:
         # Condor startd jobwrapper
         # Executes using bash -l, so that all /etc/profile.d/*.sh scripts are sourced.
         #
-
-        # Workaround for condor not setting $HOME for worker sessions.
-        # voms-proxy-info requires this.
-        export HOME=`eval echo ~$USER`
-        exec "$@"
     owner: root:root
     permissions: '0755'
     path: /usr/libexec/condor/jobwrapper.sh

--- a/belle.yaml
+++ b/belle.yaml
@@ -25,7 +25,6 @@ write_files:
         # Workaround for condor not setting $HOME for worker sessions.
         # voms-proxy-info requires this.
         export HOME=`eval echo ~$USER`
-        exec "$@"
 
         # Define atlas software location
         export VO_ATLAS_SW_DIR=/cvmfs/atlas.cern.ch/repo/sw
@@ -49,6 +48,7 @@ write_files:
         # Condor startd jobwrapper
         # Executes using bash -l, so that all /etc/profile.d/*.sh scripts are sourced.
         #
+        exec "$@"
     owner: root:root
     permissions: '0755'
     path: /usr/libexec/condor/jobwrapper.sh

--- a/belle.yaml
+++ b/belle.yaml
@@ -22,6 +22,11 @@ write_files:
             return 0
         fi
 
+        # Workaround for condor not setting $HOME for worker sessions.
+        # voms-proxy-info requires this.
+        export HOME=`eval echo ~$USER`
+        exec "$@"
+
         # Define atlas software location
         export VO_ATLAS_SW_DIR=/cvmfs/atlas.cern.ch/repo/sw
 
@@ -44,11 +49,6 @@ write_files:
         # Condor startd jobwrapper
         # Executes using bash -l, so that all /etc/profile.d/*.sh scripts are sourced.
         #
-
-        # Workaround for condor not setting $HOME for worker sessions.
-        # voms-proxy-info requires this.
-        export HOME=`eval echo ~$USER`
-        exec "$@"
     owner: root:root
     permissions: '0755'
     path: /usr/libexec/condor/jobwrapper.sh


### PR DESCRIPTION
Condor does not set the HOME variable when submitting a jobs. This is needed by some ATLAS setup scripts. These are called before the job wrapper. This was unexpected, fixed by moving the definition of home to the grid-setup.sh script in /etc/profile.d/. Concerns issue #9.